### PR TITLE
fix: support TypeScript's isolated modules

### DIFF
--- a/src/delegate.ts
+++ b/src/delegate.ts
@@ -49,6 +49,6 @@ interface Delegate<Runtime> {
   logError?(error: Error): void
 }
 
-export {
+export type {
   Delegate,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,10 @@ function cleanup(handler: (signal: SignalOrExitCode) => Promise<void>): void {
   process.removeListener('beforeExit', handler)
 }
 
+export type {
+  Delegate,
+}
+
 export {
   heimdall,
-  Delegate,
 }


### PR DESCRIPTION
fix: support TypeScript's isolated modules

<!-- 

Hi, thank you for the great library. I tried to use it, but found an error if `--isolatedModules` enabled. This PR fixes it by using `export type ...`.

![image](https://user-images.githubusercontent.com/10719495/103617033-601f9980-4f25-11eb-867f-dc1974f1a09f.png)

Thanks!
!-->