### PR TITLE
Add support of Node 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typescript": "^4.0.5"
   },
   "engines": {
-    "node": "^12 || ^14 || ^15"
+    "node": "^12 || ^14 || ^15 || ^16"
   },
   "homepage": "https://github.com/strvcom/heimdall",
   "keywords": [],


### PR DESCRIPTION
Node.js 16 is now active, so please add it. Thanks

![image](https://user-images.githubusercontent.com/10719495/153749806-f91d7cdf-5a2a-40ef-8b98-41f077ada019.png)
