### PR TITLE
feat: add support of Node ^20, ^22, ^23

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -16,6 +16,8 @@ jobs:
         node:
           - 18
           - 20
+          - 22
+          - 23
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,3 @@
-import * as os from 'os'
 import nodev20 from '@strv/eslint-config-node/v20'
 import nodeopt from '@strv/eslint-config-node/optional'
 import nodestyle from '@strv/eslint-config-node/style'
@@ -7,7 +6,6 @@ import tsoptional from '@strv/eslint-config-typescript/optional'
 import tsstyle from '@strv/eslint-config-typescript/style'
 import mocha from '@strv/eslint-config-mocha'
 
-const lbstyle = os.platform() === 'win32' ? 'windows' : 'unix'
 const globs = {
   mjs: '**/*.mjs',
   ts: '**/*.ts',
@@ -34,12 +32,6 @@ const config = [
   { files: [globs.ts],
     languageOptions: {
       parserOptions: { project: './tsconfig.json' },
-    },
-    rules: {
-      // This repository is configured so that upon checkout, git should convert line endings to platform-specific
-      // defaults and convert them back to LF when checking in. As such, we must enforce CRLF endings on Windows,
-      // otherwise the lint task would fail on Windows systems.
-      'linebreak-style': ['error', lbstyle],
     } },
 ]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "typescript": "^5.3.3"
       },
       "engines": {
-        "node": "^18 || >=20"
+        "node": "^18 || ^20 || ^22 || ^23"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typescript": "^5.3.3"
   },
   "engines": {
-    "node": "^18 || >=20"
+    "node": "^18 || ^20 || ^22 || ^23"
   },
   "homepage": "https://github.com/strvcom/heimdall",
   "keywords": [],


### PR DESCRIPTION
There are three unreleased commits in `master`, one of them already added support for Node 20, but using the version range `<=20` which also allows for all older major versions, including those for which the support has already been dropped. Changed to `^20`, following the previous convention.

CI target now runs tests also for the newly added versions (22, 23).

⚠️ Since the unreleased commit also drops support for Node versions 12, 14 and 16, the subsequent release should be a major version bump. But I guess this will be automatically handled by a CI job.

⚠️ One of these commits also migrates ESLint config to the new flat format, including the legacy override for the `linebreak-style` rule. Instead of fixing the ESLint execution for Windows platform, this override now breaks it – see [CI logs](https://github.com/strvcom/heimdall/actions/runs/12709857887/job/35429729570). Moreover, the updated base config doesn't use this rule anymore, but `@stylistic/linebreak-style` which is an equivalent successor. Since it is now not being overriden, the two rules apply at the same time, so on Windows, each of them requires the opposite style and thus it's impossible to satisfy both of them at once. I solved the issue by removing the override completely, while enforcing LF endings on Windows using the `.gitattributes` file.